### PR TITLE
Expanded the documentation a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ pip install fps-noauth
 fps-uvicorn --host=0.0.0.0 --port=8000 --no-open-browser
 ```
 
+Alternatively (if you don't have a Unix shell on your target, like in an Android app) you can add this to your Python
+code:
+```python
+from fps_uvicorn.cli import app
+app(["--host=0.0.0.0","--port=8005","--no-open-browser"])
+```
+
 ### Setup the host
 
 On your host terminal/environment (your development machine, will accept connections from your browser):

--- a/README.md
+++ b/README.md
@@ -1,25 +1,35 @@
 # Jupyter Server Kernels Proxy
 
-In one terminal/environment:
+This tool allows you to use notebooks on a target machine without installing the whole JupyterLab
+environment. The JupyterLab server will still be running on your host (development machine) but the
+kernels (notebooks) will be executed remotely.
+
+### Setup the target
+
+Inside the target terminal/environment (this will be the side running the Python kernel code):
 
 ```console
 pip install fps_uvicorn
 pip install fps_kernels
 pip install fps-noauth
 
-# launch a terminal server at http://127.0.0.1:8000
-fps-uvicorn --port=8000 --no-open-browser
+# launch a terminal server at http://0.0.0.0:8000
+# beware, it will be freely accessible to anyone on the local network!
+fps-uvicorn --host=0.0.0.0 --port=8000 --no-open-browser
 ```
 
-In another terminal/environment:
+### Setup the host
+
+On your host terminal/environment (your development machine, will accept connections from your browser):
 
 ```console
 pip install https://github.com/davidbrochart/jupyter_server/archive/kernels_extension.zip
 pip install jupyter_server_kernels_proxy
 pip install jupyterlab
 
-# launch JupyterLab at http://127.0.0.1:8888 and proxy kernels at http://127.0.0.1:8000
-jupyter lab --port=8888 --KernelsProxyExtensionApp.proxy_url='http://127.0.0.1:8000'
+# launch JupyterLab at http://127.0.0.1:8888 and run kernels at http://<ip-of-the-target>:8000
+jupyter lab --port=8888 --KernelsProxyExtensionApp.proxy_url='http://<ip-of-the-target>:8000'
 ```
 
-Kernels should now be served from http://127.0.0.1:8000.
+Kernels should now be served from http://<ip-of-the-target>:8000 and can be worked with by connecting
+to http://localhost:8888/lab .


### PR DESCRIPTION
Hi,

I wanted to improve the host/target distinction and added a way to run the kernel `fps` server without a Unix shell (figuring out the proper Click and Typer APIs was surprisingly difficult).